### PR TITLE
Add the handler file with the -r option to allow folders to be used

### DIFF
--- a/pruun/utils.py
+++ b/pruun/utils.py
@@ -71,7 +71,7 @@ def create_deployment_package(
         )
 
     subprocess.run(
-        f"zip -g {package_file_path} {handler_file}",
+        f"zip -gr {package_file_path} {handler_file}",
         stdout=subprocess.DEVNULL,
         stderr=subprocess.STDOUT,
         cwd=cwd,


### PR DESCRIPTION
Currently if you specify a handler file that is a directory, an empty directory is moved into the zip. With this change, the whole directory will be copied in.